### PR TITLE
clarify on how to reset the stroke dash array

### DIFF
--- a/doc/imagickdraw/setstrokedasharray.txt
+++ b/doc/imagickdraw/setstrokedasharray.txt
@@ -2,6 +2,5 @@ Specifies the pattern of dashes and gaps used to stroke paths. The
    strokeDashArray represents an array of numbers that specify the lengths of
    alternating dashes and gaps in pixels. If an odd number of values is
    provided, then the list of values is repeated to yield an even number of
-   values. To remove an existing dash array, pass a zero number_elements
-   argument and null dash_array. A typical strokeDashArray_ array might
-   contain the members 5 3 2.
+   values. To remove an existing dash array, pass a null strokeDashArray.
+   A typical strokeDashArray might contain the members 5 3 2.


### PR DESCRIPTION
For ImageMagick 7 it is necessary use `setStrokeDashArray(null)` instead of `setStrokeDashArray([null])` in order to reset the stroke dashes.

This should be fixed in the php documentation too: https://www.php.net/manual/en/imagickdraw.setstrokedasharray.php

Ive opened a PR for the PHPStorm Stubs already: https://github.com/JetBrains/phpstorm-stubs/pull/1818
